### PR TITLE
add possibility to only create states, but not write values by module

### DIFF
--- a/_template/stateAttr.js
+++ b/_template/stateAttr.js
@@ -9,8 +9,8 @@
 		rootName: 'Device Info channel,		// {default: NotUsed} Upper channel name
 		name: 'Name of state',				// {default: same as id} Name definition for object
 		type: >typeof (value)<,				// {default: typeof (value)} type of value automatically detected
-		read: true,							// {default: true} Name defition for object
-		write: true,						// {default: false} Name defition for object
+		read: true,							// {default: true} Name definition for object
+		write: true,						// {default: false} Name definition for object
 		role: 'indicator.info',				// {default: state} Role as defined by https://github.com/ioBroker/ioBroker/blob/master/doc/STATE_ROLES.md
 		modify: ''							// {default: ''} see below
 	},
@@ -18,11 +18,11 @@
 
 /**
  * Defines supported methods for element modify which can be used in stateAttr.js
- * In addition: 'cumstom: YOUR CALCULATION' allows any calculation, where 'value' is the input parameter.
- * Example: 
+ * In addition: 'custom: YOUR CALCULATION' allows any calculation, where 'value' is the input parameter.
+ * Example:
  * modify: 'custom: value + 1' --> add 1 to the json-input
- * 
- *  * supported methods (as string): 
+ *
+ *  * supported methods (as string):
  *  - round(number_of_digits as {number})  //integer only
  * 	- multiply(factor as {number})
  *  - divide(factor as {number})
@@ -31,11 +31,12 @@
  *  - upperCase
  *  - lowerCase
  *  - ucFirst
- * 
- * Examples for usage of embeded methods:
+ *  - IGNOREVALUE , to be used if value needs modification and should not be written by this module
+ *
+ * Examples for usage of embedded methods:
  * modify: ['multiply(3.6)', 'round(2)'] --> defined as array --> multiplied by 3.6 and then the result is rounded by 2 digits
  * modify: 'upperCase' --> no array needed as there is only one action; this uppercases the string
- * 
+ *
  */
 
 /**

--- a/jsonExplorer.js
+++ b/jsonExplorer.js
@@ -308,7 +308,7 @@ async function stateSetCreate(objName, name, value) {
 
             if (typeof (value) == 'object' && value != null && value.ignore) {
                 // ignore write of value
-                adapter.log.warn(`Value ignored for ${objName} | ${value}`)
+                adapter.log.silly(`Value ignored for ${objName} | ${value}`)
 
 
             } else {

--- a/jsonExplorer.js
+++ b/jsonExplorer.js
@@ -175,6 +175,14 @@ function modify(method, value) {
                 case 'UCFIRST':
                     if (typeof value == 'string') result = value.substring(0, 1).toUpperCase() + value.substring(1).toLowerCase();
                     break;
+
+                case 'IGNOREVALUE':
+                    value = {
+                        value: value,
+                        ignore: true
+                    };
+                    break;
+
                 default:
                     result = value;
             }
@@ -297,10 +305,19 @@ async function stateSetCreate(objName, name, value) {
                 }
             }
             adapter.log.silly(`State "${objName}" set with value "${value}`);
-            await adapter.setStateAsync(objName, {
-                val: value,
-                ack: true
-            });
+
+            if (typeof (value) == 'object' && value != null && value.ignore) {
+                // ignore write of value
+                adapter.log.warn(`Value ignored for ${objName} | ${value}`)
+
+
+            } else {
+                await adapter.setStateAsync(objName, {
+                    val: value,
+                    ack: true
+                });
+            }
+
         }
 
         // Timer to set online state to FALSE when not updated


### PR DESCRIPTION
Manchmal is es praktisch das dieses Modul werte (values) nicht schreibt da diese noch konvertiert oder anderweitig bearbeitet werden müssen. 
Dazu habe ich im modify die option ignoreValue implementiert, dadurch wird der state zwar erstellt aber kein wert geschrieben.

Das ist praktisch wen man werte aus einer array erst konvertieren muss, in diesem fall muss der wert dan im adapter code geschrieben werden, das object wird aber trotzdem erstellt was wieder code in der main spart :)